### PR TITLE
Makes can-list work with can-map-define

### DIFF
--- a/can-list.js
+++ b/can-list.js
@@ -146,6 +146,11 @@ var List = Map.extend(
 		},
 		___get: function (attr) {
 			if (attr) {
+				var computedAttr = this._computedAttrs[attr];
+				if(computedAttr && computedAttr.compute) {
+					return computedAttr.compute();
+				}
+
 				if (this[attr] && this[attr].isComputed && typeof this.constructor.prototype[attr] === "function" ) {
 					return this[attr]();
 				} else {

--- a/can-list_test.js
+++ b/can-list_test.js
@@ -1,6 +1,7 @@
 var List = require('can-list');
 var QUnit = require('steal-qunit');
 var Observation = require('can-observation');
+require("can-map-define");
 
 QUnit.module('can-list');
 
@@ -358,4 +359,19 @@ test("list is always updated with the last promise passed to replace (#2136)", f
 			resolve([ "B" ]);
 		}, 10 );
 	}));
+});
+
+test("works with can-map-define", function() {
+	var MyList = List.extend({}, {
+		define: {
+			foo: {
+				get: function(){
+					return "bar";
+				}
+			}
+		}
+	});
+
+	var list = new MyList();
+	equal(list.attr("foo"), "bar");
 });

--- a/package.json
+++ b/package.json
@@ -54,15 +54,16 @@
   },
   "devDependencies": {
     "bit-docs": "0.0.6",
-    "jshint": "^2.9.1",
+    "can-map-define": "^3.0.0-pre.2",
     "cssify": "^1.0.2",
+    "done-serve": "^0.2.0",
+    "donejs-cli": "^0.9.5",
+    "generator-donejs": "^0.9.0",
+    "jshint": "^2.9.1",
     "steal": "^0.16.0",
     "steal-qunit": "^0.1.1",
     "steal-tools": "^0.16.0",
-    "testee": "^0.2.4",
-    "generator-donejs": "^0.9.0",
-    "donejs-cli": "^0.9.5",
-    "done-serve": "^0.2.0"
+    "testee": "^0.2.4"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This fixes it so that can-list works with can-map-define. When the
getter is run, check if `_computedAttrs` includes the attr and if so,
run its associated compute.

Fixes #10