### PR TITLE
Added fix from issue #3 and made test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ node_modules
 
 doc/
 dist/
+.idea/

--- a/can-list.js
+++ b/can-list.js
@@ -14,7 +14,6 @@ var makeArray = require('can-util/js/make-array/make-array');
 var assign = require('can-util/js/assign/assign');
 var types = require('can-util/js/types/types');
 var each = require('can-util/js/each/each');
-var types = require("can-util/js/types/types");
 
 
 
@@ -764,12 +763,27 @@ assign(List.prototype, {
 	 * );
 	 * newList.attr(); // ['Alice', 'Bob', 'Charlie', 'Daniel', 'Eve', {f: 'Francis'}]
 	 * ```
-	 */	
-	concat: function () {
-		var args = [];
-		each(makeArray(arguments), function (arg, i) {
-			args[i] = (arg instanceof Map) ? arg.serialize() : arg;
+	 */
+
+	concat: function() {
+
+		var args = [],
+			MapType = this.constructor.Map;
+
+		each(arguments, function(arg) {
+			if(types.isListLike(arg)) {
+				var arr = makeArray(arg);
+				if(arr && arr.serialize && (arr instanceof MapType)) {
+					args.push.apply(args, new MapType(arr.serialize()));
+				} else {
+					args.push.apply(args, arr);
+				}
+			}
+			else {
+				args.push.apply(args, arg);
+			}
 		});
+
 		return new this.constructor(Array.prototype.concat.apply(makeArray(this), args));
 	},
 

--- a/can-list.js
+++ b/can-list.js
@@ -764,12 +764,11 @@ assign(List.prototype, {
 	 * );
 	 * newList.attr(); // ['Alice', 'Bob', 'Charlie', 'Daniel', 'Eve', {f: 'Francis'}]
 	 * ```
-	 */
+	 */	
 	concat: function () {
 		var args = [];
-		var MapType = this.constructor.Map;
 		each(makeArray(arguments), function (arg, i) {
-			args[i] = (arg instanceof Map) && !(arg instanceof MapType) ? arg.serialize() : arg;
+			args[i] = (arg instanceof Map) ? arg.serialize() : arg;
 		});
 		return new this.constructor(Array.prototype.concat.apply(makeArray(this), args));
 	},

--- a/can-list.js
+++ b/can-list.js
@@ -30,6 +30,17 @@ var splice = [].splice,
 		return !obj[0];
 	})();
 
+// Function that serializes the passed arg if
+// type does not match MapType of `this` list
+// then adds to args array
+var serializeNonTypes = function(MapType, arg, args) {
+	if(arg && arg.serialize && !(arg instanceof MapType)) {
+		args.push(new MapType(arg.serialize()));
+	} else {
+		args.push(arg);
+	}
+};
+
 /**
  * @add can.List
  */
@@ -204,16 +215,6 @@ var List = Map.extend(
 		 */
 		serialize: function () {
 			return mapHelpers.serialize(this, 'serialize', []);
-		},
-		// Function that serializes the passed arg if
-		// type does not match MapType of `this` list
-		// then adds to args array
-		serializeNonTypes: function(MapType, arg, args) {
-			if(arg && arg.serialize && !(arg instanceof MapType)) {
-				args.push(new MapType(arg.serialize()));
-			} else {
-				args.push(arg);
-			}
 		},
 		/**
 		 * @function can.List.prototype.each each
@@ -776,7 +777,6 @@ assign(List.prototype, {
 	 */
 	concat: function() {
 		var args = [],
-			serializeNonTypes = this.serializeNonTypes,
 			MapType = this.constructor.Map;
 		// Go through each of the passed `arguments` and 
 		// see if it is list-like, an array, or something else

--- a/can-list.js
+++ b/can-list.js
@@ -764,40 +764,6 @@ assign(List.prototype, {
 	 * newList.attr(); // ['Alice', 'Bob', 'Charlie', 'Daniel', 'Eve', {f: 'Francis'}]
 	 * ```
 	 */
-
-	// concat: function () {
-	// 	var args = [];
-	// 	each(makeArray(arguments), function (arg, i) {
-	// 		args[i] = (arg instanceof Map) ? arg.serialize() : arg;
-	// 	});
-	// 	return new this.constructor(Array.prototype.concat.apply(makeArray(this), args));
-	// },
-
-	// concat: function() {
-  //
-	// 	var args = [],
-	// 		MapType = this.constructor.Map;
-  //
-	// 	each(arguments, function(arg) {
-	// 		if(types.isListLike(arg)) {
-	// 			args.push.apply(args, makeArray(arg));
-	// 		}
-	// 		else {
-	// 			args.push(arg);
-	// 		}
-	// 	});
-  //
-	// 	args = args.map(function(arg) {
-	// 		if(arg && arg.serialize && !(arg instanceof MapType)) {
-	// 			return new MapType(arg.serialize());
-	// 		} else {
-	// 			return arg;
-	// 		}
-	// 	});
-  //
-	// 	return new this.constructor(Array.prototype.concat.apply(makeArray(this), args));
-	// },
-
 	concat: function() {
 
 		var args = [],
@@ -813,15 +779,20 @@ assign(List.prototype, {
 				}
 			};
 		
-		// Go through each of the passed `arguments` and
-		// if it is list-like we want to make it a JS array for now
-		// then decide if we want to serialize
+		// Go through each of the passed `arguments` and 
+		// see if it is list-like, an array, or something else
 		each(arguments, function(arg) {
-			if(types.isListLike(arg)) {
-				var arr = makeArray(arg);
-				serializeNonTypes(arr);
+			if(types.isListLike(arg) || Array.isArray(arg)) {
+				// If it is list-like we want convert to a JS array then
+				// pass each item of the array to serializeNonTypes
+				var arr = types.isListLike(arg) ? makeArray(arg) : arg;
+				each(arr, function(innerArg) {
+					serializeNonTypes(innerArg);
+				});
 			}
 			else {
+				// If it is a Map, Object, or some primitive 
+				// just pass arg to serializeNonTypes
 				serializeNonTypes(arg);
 			}
 		});

--- a/can-list.js
+++ b/can-list.js
@@ -767,10 +767,11 @@ assign(List.prototype, {
 	 */
 	concat: function () {
 		var args = [];
+		var MapType = this.constructor.Map;
 		each(makeArray(arguments), function (arg, i) {
-			args[i] = arg instanceof List ? arg.serialize() : arg;
+			args[i] = (arg instanceof Map) && !(arg instanceof MapType) ? arg.serialize() : arg;
 		});
-		return new this.constructor(Array.prototype.concat.apply(this.serialize(), args));
+		return new this.constructor(Array.prototype.concat.apply(makeArray(this), args));
 	},
 
 	/**

--- a/can-list.js
+++ b/can-list.js
@@ -765,25 +765,71 @@ assign(List.prototype, {
 	 * ```
 	 */
 
+	// concat: function () {
+	// 	var args = [];
+	// 	each(makeArray(arguments), function (arg, i) {
+	// 		args[i] = (arg instanceof Map) ? arg.serialize() : arg;
+	// 	});
+	// 	return new this.constructor(Array.prototype.concat.apply(makeArray(this), args));
+	// },
+
+	// concat: function() {
+  //
+	// 	var args = [],
+	// 		MapType = this.constructor.Map;
+  //
+	// 	each(arguments, function(arg) {
+	// 		if(types.isListLike(arg)) {
+	// 			args.push.apply(args, makeArray(arg));
+	// 		}
+	// 		else {
+	// 			args.push(arg);
+	// 		}
+	// 	});
+  //
+	// 	args = args.map(function(arg) {
+	// 		if(arg && arg.serialize && !(arg instanceof MapType)) {
+	// 			return new MapType(arg.serialize());
+	// 		} else {
+	// 			return arg;
+	// 		}
+	// 	});
+  //
+	// 	return new this.constructor(Array.prototype.concat.apply(makeArray(this), args));
+	// },
+
 	concat: function() {
 
 		var args = [],
-			MapType = this.constructor.Map;
-
+			MapType = this.constructor.Map,
+			// Function that serializes the passed arg if
+			// type does not match MapType of `this` list
+			// then adds to args array
+			serializeNonTypes = function(arg) {
+				if(arg && arg.serialize && !(arg instanceof MapType)) {
+					args.push(new MapType(arg.serialize()));
+				} else {
+					args.push(arg);
+				}
+			};
+		
+		// Go through each of the passed `arguments` and
+		// if it is list-like we want to make it a JS array for now
+		// then decide if we want to serialize
 		each(arguments, function(arg) {
 			if(types.isListLike(arg)) {
 				var arr = makeArray(arg);
-				if(arr && arr.serialize && (arr instanceof MapType)) {
-					args.push.apply(args, new MapType(arr.serialize()));
-				} else {
-					args.push.apply(args, arr);
-				}
+				serializeNonTypes(arr);
 			}
 			else {
-				args.push.apply(args, arg);
+				serializeNonTypes(arg);
 			}
 		});
 
+		// We will want to make `this` list into a JS array
+		// as well (We know it should be list-like), then
+		// concat with our passed in args, then pass it to
+		// list constructor to make it back into a list
 		return new this.constructor(Array.prototype.concat.apply(makeArray(this), args));
 	},
 

--- a/can-list.js
+++ b/can-list.js
@@ -205,6 +205,16 @@ var List = Map.extend(
 		serialize: function () {
 			return mapHelpers.serialize(this, 'serialize', []);
 		},
+		// Function that serializes the passed arg if
+		// type does not match MapType of `this` list
+		// then adds to args array
+		serializeNonTypes: function(MapType, arg, args) {
+			if(arg && arg.serialize && !(arg instanceof MapType)) {
+				args.push(new MapType(arg.serialize()));
+			} else {
+				args.push(arg);
+			}
+		},
 		/**
 		 * @function can.List.prototype.each each
 		 * @description Call a function on each element of a List.
@@ -765,20 +775,9 @@ assign(List.prototype, {
 	 * ```
 	 */
 	concat: function() {
-
 		var args = [],
-			MapType = this.constructor.Map,
-			// Function that serializes the passed arg if
-			// type does not match MapType of `this` list
-			// then adds to args array
-			serializeNonTypes = function(arg) {
-				if(arg && arg.serialize && !(arg instanceof MapType)) {
-					args.push(new MapType(arg.serialize()));
-				} else {
-					args.push(arg);
-				}
-			};
-		
+			serializeNonTypes = this.serializeNonTypes,
+			MapType = this.constructor.Map;
 		// Go through each of the passed `arguments` and 
 		// see if it is list-like, an array, or something else
 		each(arguments, function(arg) {
@@ -787,13 +786,13 @@ assign(List.prototype, {
 				// pass each item of the array to serializeNonTypes
 				var arr = types.isListLike(arg) ? makeArray(arg) : arg;
 				each(arr, function(innerArg) {
-					serializeNonTypes(innerArg);
+					serializeNonTypes(MapType, innerArg, args);
 				});
 			}
 			else {
 				// If it is a Map, Object, or some primitive 
 				// just pass arg to serializeNonTypes
-				serializeNonTypes(arg);
+				serializeNonTypes(MapType, arg, args);
 			}
 		});
 

--- a/can-list_test.js
+++ b/can-list_test.js
@@ -1,6 +1,7 @@
 var List = require('can-list');
 var QUnit = require('steal-qunit');
 var Observation = require('can-observation');
+var Map = require('can-map');
 require("can-map-define");
 
 QUnit.module('can-list');
@@ -174,7 +175,7 @@ test('Array accessor methods', 11, function () {
 	});
 });
 
-test('Concated list Equals original', function() {
+test('Concatenated list items Equal original', function() {
 	var l = new List([
 		{ firstProp: "Some data" },
 		{ secondProp: "Next data" }
@@ -183,10 +184,31 @@ test('Concated list Equals original', function() {
 		{ hello: "World" },
 		{ foo: "Bar" }
 	]);
-	
+
 	ok(l[0] === concatenated[0], "They are Equal");
 	ok(l[1] === concatenated[1], "They are Equal");
+
+});
+
+test('Lists with maps concatenate properly', function() {
+	Person = Map.extend();
+	People = List.extend({
+		Map: Person
+	},{});
+	Genius = Person.extend();
+	Animal = Map.extend();
 	
+	var me = new Person({ name: "John" });
+	var animal = new Animal({ name: "Tak" });
+	var genius = new Genius({ name: "Einstein" });
+	var hero = { name: "Ghandi" };
+	
+	var people = new People([]);
+	people = people.concat(me, animal, genius, hero, [1, 2], 3);
+	
+	ok(people.attr('length') === 7, "List length is right");
+	ok(people[0] === me, "Map in list === vars created before concat");
+	ok(people[1] instanceof Person, "Animal got serialized to Person");
 });
 
 test('splice removes items in IE (#562)', function () {

--- a/can-list_test.js
+++ b/can-list_test.js
@@ -191,12 +191,12 @@ test('Concatenated list items Equal original', function() {
 });
 
 test('Lists with maps concatenate properly', function() {
-	Person = Map.extend();
-	People = List.extend({
+	var Person = Map.extend();
+	var People = List.extend({
 		Map: Person
 	},{});
-	Genius = Person.extend();
-	Animal = Map.extend();
+	var Genius = Person.extend();
+	var Animal = Map.extend();
 	
 	var me = new Person({ name: "John" });
 	var animal = new Animal({ name: "Tak" });
@@ -204,9 +204,14 @@ test('Lists with maps concatenate properly', function() {
 	var hero = { name: "Ghandi" };
 	
 	var people = new People([]);
-	people = people.concat(me, animal, genius, hero, [1, 2], 3);
+	var specialPeople = new People([
+		genius,
+		hero
+	]);
 	
-	ok(people.attr('length') === 7, "List length is right");
+	people = people.concat([me, animal, specialPeople], specialPeople, [1, 2], 3);
+	
+	ok(people.attr('length') === 8, "List length is right");
 	ok(people[0] === me, "Map in list === vars created before concat");
 	ok(people[1] instanceof Person, "Animal got serialized to Person");
 });

--- a/can-list_test.js
+++ b/can-list_test.js
@@ -174,7 +174,7 @@ test('Array accessor methods', 11, function () {
 	});
 });
 
-test('Concated list deepEquals original', function() {
+test('Concated list Equals original', function() {
 	var l = new List([
 		{ firstProp: "Some data" },
 		{ secondProp: "Next data" }
@@ -184,9 +184,9 @@ test('Concated list deepEquals original', function() {
 		{ foo: "Bar" }
 	]);
 	
-	deepEqual(l[0], concatenated[0], "They deep equal");
-	deepEqual(l[1], concatenated[1], "They deep equal");
-	deepEqual(concatenated[2], (concatenated.concat())[2]);
+	ok(l[0] === concatenated[0], "They are Equal");
+	ok(l[1] === concatenated[1], "They are Equal");
+	
 });
 
 test('splice removes items in IE (#562)', function () {

--- a/can-list_test.js
+++ b/can-list_test.js
@@ -137,6 +137,7 @@ test('always gets right attr even after moving array items', function () {
 	});
 	o.attr('foo', 'led you');
 });
+
 test('Array accessor methods', 11, function () {
 	var l = new List([
 		'a',
@@ -160,7 +161,7 @@ test('Array accessor methods', 11, function () {
 		'c',
 		2,
 		1,
-		0
+		[0]
 	], 'List concatenated properly');
 	l.forEach(function (letter, index) {
 		ok(true, 'Iteration');
@@ -172,12 +173,22 @@ test('Array accessor methods', 11, function () {
 		}
 	});
 });
+
+test('Concated list deepEquals original', function() {
+	var l = new List([
+		{ firstProp: "Some data" },
+		{ secondProp: "Next data" }
+	]),
+	concatenated = l.concat(["Hello", "World"]);
+	
+	deepEqual(l[0], concatenated[0], "They deep equal");
+});
+
 test('splice removes items in IE (#562)', function () {
 	var l = new List(['a']);
 	l.splice(0, 1);
 	ok(!l.attr(0), 'all props are removed');
 });
-
 
 test('reverse triggers add/remove events (#851)', function() {
 	expect(6);

--- a/can-list_test.js
+++ b/can-list_test.js
@@ -161,7 +161,7 @@ test('Array accessor methods', 11, function () {
 		'c',
 		2,
 		1,
-		[0]
+		0
 	], 'List concatenated properly');
 	l.forEach(function (letter, index) {
 		ok(true, 'Iteration');
@@ -179,9 +179,14 @@ test('Concated list deepEquals original', function() {
 		{ firstProp: "Some data" },
 		{ secondProp: "Next data" }
 	]),
-	concatenated = l.concat(["Hello", "World"]);
+	concatenated = l.concat([
+		{ hello: "World" },
+		{ foo: "Bar" }
+	]);
 	
 	deepEqual(l[0], concatenated[0], "They deep equal");
+	deepEqual(l[1], concatenated[1], "They deep equal");
+	deepEqual(concatenated[2], (concatenated.concat())[2]);
 });
 
 test('splice removes items in IE (#562)', function () {


### PR DESCRIPTION
Closes #3 

Please review changed line https://github.com/canjs/can-list/blob/3-concat-deep-equals/can-list_test.js#L164 Based on discussion https://github.com/canjs/canjs/issues/1616#issuecomment-141188626 to make sure this is what we want.

Concatenating a map will to the list will no longer serialize that map.