### PR TITLE
Fix #3182 (can.List.map doesn't properly handle context arg)

### DIFF
--- a/can-list.js
+++ b/can-list.js
@@ -927,7 +927,7 @@ assign(List.prototype, {
 			self = this,
 			filtered;
 		this.each(function(item, index, list){
-			filtered = callback.call( thisArg | self, item, index, self);
+			filtered = callback.call( thisArg || self, item, index, self);
 			if(filtered){
 				filteredList.push(item);
 			}
@@ -938,7 +938,7 @@ assign(List.prototype, {
 		var filteredList = new List(),
 			self = this;
 		this.each(function(item, index, list){
-			var mapped = callback.call( thisArg | self, item, index, self);
+			var mapped = callback.call( thisArg || self, item, index, self);
 			filteredList.push(mapped);
 
 		});

--- a/can-list_test.js
+++ b/can-list_test.js
@@ -440,3 +440,30 @@ test('each callback', function () {
 	});
 	equal(counter, 1, 'Should not be invoked for uninitialized attr keys');
 });
+
+test('filter with context', function(){
+	var l = new List([{id: 1}]);
+	var context = {};
+	var contextWasCorrect = false;
+
+	l.filter(function(){
+		contextWasCorrect = (this === context);
+		return true;
+	}, context);
+
+	equal(contextWasCorrect, true, "context was correctly passed");
+});
+
+test('map with context', function(){
+	var l = new List([{id: 1}]);
+	var context = {};
+	var contextWasCorrect = false;
+
+	l.map(function(){
+		contextWasCorrect = (this === context);
+		return true;
+	}, context);
+
+	equal(contextWasCorrect, true, "context was correctly passed");
+});
+


### PR DESCRIPTION
Addresses https://github.com/canjs/canjs/issues/3182. Fixes the issue in both `map()` and the `filter()` functions of using a bitwise instead of logical or as a short-circuit to determine the context to be passed to the client callback function.