### PR TITLE
chore(package): update can-event to version 3.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "can-cid": "^1.0.0",
     "can-compute": "^3.3.1",
     "can-construct": "^3.2.0-pre.0",
-    "can-event": "^3.5.0-pre.2",
+    "can-event": "^3.6.0",
     "can-map": "^3.3.1",
     "can-namespace": "1.0.0",
     "can-observation": "^3.3.1",


### PR DESCRIPTION
Closes #42 