### PR TITLE
Use non-prerelease dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,16 +38,16 @@
     "can-event-queue": "<2.0.0",
     "can-namespace": "^1.0.0",
     "can-observation-recorder": "<2.0.0",
-    "can-observation": "^4.0.0-pre.19",
+    "can-observation": "^4.0.0",
     "can-reflect": "^1.7.2",
-    "can-simple-observable": "^2.0.0-pre.16",
-    "can-stache-key": "^1.0.0-pre.9",
+    "can-simple-observable": "^2.0.0",
+    "can-stache-key": "^1.0.0",
     "can-symbol": "^1.4.1",
     "can-types": "^1.1.0",
     "can-util": "^3.10.12",
-    "can-compute": "^4.0.0-pre.1",
+    "can-compute": "^4.0.0",
     "can-queues": "<2.0.0",
-    "can-map": "^4.0.0-pre.5"
+    "can-map": "^4.0.0"
   },
   "devDependencies": {
     "detect-cyclic-packages": "^1.1.0",


### PR DESCRIPTION
This removes the use of prereleases.