### PR TITLE
Make can-list dispatch patches

### DIFF
--- a/can-list_test.js
+++ b/can-list_test.js
@@ -640,3 +640,19 @@ QUnit.test('list.sort a list of objects without losing reference (#137)', functi
 	});
 	equal(unSorted[0], sorted[2], 'items should be equal');
 });
+
+QUnit.test("list receives patch events", function() {
+	QUnit.expect(2);
+	var list = new List([]);
+
+	function handler(patches) {
+		if(patches[0].index === 0 && patches[0].insert) {
+			QUnit.ok(true);
+		}
+	}
+	canReflect.onPatches(list, handler);
+
+	list.push("foo");
+	list.attr(0, "bar");
+	canReflect.offPatches(list, handler);
+});


### PR DESCRIPTION
Closes #90 and will close https://github.com/canjs/can-stache/issues/685 when a new version of can-list is published.